### PR TITLE
Make Map null friendly

### DIFF
--- a/src/state/default_factory.js
+++ b/src/state/default_factory.js
@@ -4,6 +4,7 @@ import TypedNode from '../node';
 import Boolean from './boolean';
 import Number from './number';
 import String from './string';
+import Null from './null';
 import List from './list';
 import Map from './map';
 
@@ -23,6 +24,8 @@ export default new Factory((value) => {
       return new Number(value);
     case 'Boolean':
       return new Boolean(value);
+    case 'Null':
+      return new Null(value);
     default:
       return value;
   }

--- a/src/state/null.js
+++ b/src/state/null.js
@@ -1,0 +1,9 @@
+import TypedNode from '../node';
+
+export default class Null extends TypedNode {
+  constructor() {
+    super();
+
+    this.value = null;
+  }
+}

--- a/test/state/map.js
+++ b/test/state/map.js
@@ -104,4 +104,10 @@ describe('Map', () => {
     map.set({ x: {} });
     assert.deepEqual(map.find('x').get(), {});
   });
+
+  it.only('set map with Null value', () => {
+    const map = new State.Map({ x: null });
+
+    assert.deepEqual(map.get(), { x: null });
+  });
 });


### PR DESCRIPTION
Since many APIs returns the nulls instead of an empty string/empty value. It will be great for the quantizer to handle it smoothly. Add Null TypedNode.
This PR includes a test.
This PR fix next error:
Before:
```
>> const map = new State.Map({ x: null });
>> map.get();
TypeError: Cannot read property 'get' of null
      at Map.getAttribute (src/state/map.js:41:35)
      at Map.get (src/state/map.js:92:26)
      at Context.<anonymous> (test/state/map.js:115:36)
```
After:
```
>> const map = new State.Map({ x: null });
>> map.get();
<< { x: null }
```

It doesn't change the behavior of validation schema:
```
>> const schema = new Schema('A', { x: Type.String });
>> const map = new State.Map({ x: null }, schema);
Error: '\nA {\n  x: \'Expected String but Null\'\n}\n'
```