### PR TITLE
Add Factory typescript typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,3 +58,8 @@ export class Type {
   static UUID: Type;
   static ObjectID: Type;
 }
+
+export class Factory<I, O> {
+  constructor(factory: (I) => O);
+  get(data: I): O;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quantizer",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "State Management System",
   "main": "./dist/quantizer",
   "scripts": {


### PR DESCRIPTION
Usage example:
```ts
interface Input {
  type: string;
}
class A {}
class B {}

const factory = new Factory<Input, A|B>((data: Input) => {
 if (data.type === 'A') {
  return new A();
 }
 return new B();
});
```